### PR TITLE
Add PHP 7.4 build / tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - "7.2"
   - "7.3"
   - "7.4snapshot"
-  - nightly # 8.0
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - "7.1"
   - "7.2"
   - "7.3"
+  - "7.4snapshot"
+  - nightly # 8.0
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ _If you want to see more services added, feel free to [open an issue](https://gi
 
 ## Prerequisites 📚
 
-* `PHP 7.1` or higher (Tested on: PHP `7.1` ✅, `7.2` ✅ and `7.3` ✅)
+* `PHP 7.1` or higher (Tested on: PHP `7.1` ✅, `7.2` ✅, `7.3` ✅ and `7.4` ✅)
 * The [`composer`](https://getcomposer.org) dependency manager for PHP
 * An account with one or more of the [API providers](#supported-apis-) listed above
 


### PR DESCRIPTION
PHP 7.4 is due to be released at the end of November. Add Travis PHP 7.4 builds to test this.